### PR TITLE
More OSX fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ DESTINATION ${CMAKE_INSTALL
 install(DIRECTORY pd-help/ DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 #Dependencies: availability
+#Non-standard openssl path on OSX
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+endif()
+find_package(OpenSSL)
+
 INCLUDE(CheckLibraryExists)
 set(CMAKE_REQUIRED_LIBRARIES fftw3 gsm json-c m opus sndfile speex websockets)
 find_library(HAVE_FFTW fftw3)
@@ -123,9 +129,10 @@ else()
 endif()
 
 #PD-External: connectivity
-if(NOT HAVE_JSON OR NOT HAVE_WEBSOCKETS OR NOT HAVE_WEBSOCKETS_COMPATIBLE)
-	message(WARNING "libjson-c or libwebsockets(compatible version) not found: websocket_recv_client and websocket_recv_server will not be build.")
+if(NOT HAVE_JSON OR NOT HAVE_WEBSOCKETS OR NOT HAVE_WEBSOCKETS_COMPATIBLE OR NOT OpenSSL_FOUND)
+	message(WARNING "OpenSSL, libjson-c or libwebsockets(compatible version) not found: websocket_recv_client and websocket_recv_server will not be build.")
 else()
+  include_directories(${OPENSSL_ROOT_DIR}/include)
 	add_library(websocket_recv_client SHARED src/connectivity/websocket_recv_client.c)
 	target_link_libraries(websocket_recv_client websockets json-c)
 

--- a/src/degradations/gsm_tilde.c
+++ b/src/degradations/gsm_tilde.c
@@ -25,11 +25,7 @@ Outlets:
 #include "ringbuffer.h"
 #include "generic_codec.h"
 
-#ifdef __APPLE__
 #include <gsm.h>
-#else
-#include <gsm/gsm.h>
-#endif
 
 static t_class *gsm_tilde_class;
 

--- a/src/degradations/gsm_tilde.c
+++ b/src/degradations/gsm_tilde.c
@@ -25,7 +25,11 @@ Outlets:
 #include "ringbuffer.h"
 #include "generic_codec.h"
 
+#ifdef __APPLE__
+#include <gsm.h>
+#else
 #include <gsm/gsm.h>
+#endif
 
 static t_class *gsm_tilde_class;
 

--- a/third-party/lpc10/lpc10.h
+++ b/third-party/lpc10/lpc10.h
@@ -13,28 +13,8 @@ $Log: lpc10.h,v $
 #define LPC10_SAMPLES_PER_FRAME 180
 #define LPC10_BITS_IN_COMPRESSED_FRAME 54
 
-
-/*
-
-  The "#if defined"'s in this file are by no means intended to be
-  complete.  They are what Nautilus uses, which has been successfully
-  compiled under DOS with the Microsoft C compiler, and under a few
-  versions of Unix with the GNU C compiler.
-
- */
-
-#if defined(unix) || defined(__unix) || defined(__APPLE__)
 typedef short		INT16;
 typedef int		INT32;
-#endif
-
-
-#if defined(__MSDOS__) || defined(MSDOS)
-typedef int		INT16;
-typedef long		INT32;
-#endif
-
-
 
 /* The initial values for every member of this structure is 0, except
    where noted in comments. */

--- a/third-party/lpc10/lpc10.h
+++ b/third-party/lpc10/lpc10.h
@@ -23,7 +23,7 @@ $Log: lpc10.h,v $
 
  */
 
-#if defined(unix) || defined(__unix)
+#if defined(unix) || defined(__unix) || defined(__APPLE__)
 typedef short		INT16;
 typedef int		INT32;
 #endif


### PR DESCRIPTION
- CMakeLists.txt: Adds non-standard OpenSSL
- gsm_tilde.c: finds <gsm.h>
- lpc10.h: defines short and int